### PR TITLE
Honor encoder inversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+frc-characterization has been archived. The features it provided are now a part of [sysid](https://github.com/wpilibsuite/sysid).
+
 # Robot Characterization Toolsuite
 
 This is a toolsuite for characterization of FRC robot mechanisms.  The characterization tools consist of a python application that runs on the user's PC, and matching robot code that runs on the user's robot.  The PC application will send control signals to the robot over network tables, while the robot sends data back to the application.  The application then processes the data and determines  characterization parameters for the user's robot mechanism, as well as producing diagnostic plots.  Data can be saved (in JSON format) for future use, if desired.

--- a/frc_characterization/logger_analyzer/templates/Robot.java.mako
+++ b/frc_characterization/logger_analyzer/templates/Robot.java.mako
@@ -197,11 +197,16 @@ public class Robot extends TimedRobot {
 
             % if brushed or useDataPort:
         encoder.setInverted(${str(rightEncoderInverted).lower()});
-            % endif
         rightEncoderPosition = ()
           -> encoder.getPosition() * encoderConstant;
         rightEncoderRate = ()
           -> encoder.getVelocity() * encoderConstant / 60.;
+            % else:
+        rightEncoderPosition = ()
+          -> ${'-' if rightEncoderInverted else ''}encoder.getPosition() * encoderConstant;
+        rightEncoderRate = ()
+          -> ${'-' if rightEncoderInverted else ''}encoder.getVelocity() * encoderConstant / 60.;
+            % endif
           % endif
         % endif
 
@@ -234,11 +239,16 @@ public class Robot extends TimedRobot {
           % else:
             % if brushed or useDataPort:
         encoder.setInverted(${str(encoderInverted).lower()});
-            % endif
         leftEncoderPosition = ()
           -> encoder.getPosition() * encoderConstant;
         leftEncoderRate = ()
           -> encoder.getVelocity() * encoderConstant / 60.;
+            % else:
+        leftEncoderPosition = ()
+          -> ${'-' if encoderInverted else ''}encoder.getPosition() * encoderConstant;
+        leftEncoderRate = ()
+          -> ${'-' if encoderInverted else ''}encoder.getVelocity() * encoderConstant / 60.;
+            % endif
           % endif
         % endif
 


### PR DESCRIPTION
When you use SparkMax mode with brushless motors and no data port, then the settings to invert the encoders are quietly discarded.  As a comment in the code points out, this is because:
    SPARK MAX DOESN"T BRUSHLESS DOESN"T LIKE INVERTING
I have fixed this by inserting a minus sign into the position and rate suppliers.